### PR TITLE
Expose the ngrok_address as the start_ngrok function return value

### DIFF
--- a/flask_ngrok.py
+++ b/flask_ngrok.py
@@ -74,6 +74,7 @@ def start_ngrok(port):
     ngrok_address = _run_ngrok(port)
     print(f" * Running on {ngrok_address}")
     print(f" * Traffic stats available on http://127.0.0.1:4040")
+    return ngrok_address
 
 
 def run_with_ngrok(app):


### PR DESCRIPTION
It's nice to be able to call a "public" (non-underscore) function like `start_ngrok` instead of `_run_ngrok`, so this simply forwards back the ngrok address as the return value.