### PR TITLE
Support for ARM architecture devices

### DIFF
--- a/flask_ngrok.py
+++ b/flask_ngrok.py
@@ -53,7 +53,12 @@ def _download_ngrok(ngrok_path):
     elif system == "Windows":
         url = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-windows-amd64.zip"
     elif system == "Linux":
-        url = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip"
+        if 'arm' in os.uname().machine and platform.architecture()[0] == '64bit':
+            url="https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-arm64.zip"
+        elif 'arm' in os.uname().machine and platform.architecture()[0] == '32bit':
+            url="https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-arm.zip"
+        else:
+            url = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip"
     else:
         raise Exception(f"{system} is not supported")
     download_path = _download_file(url)
@@ -92,3 +97,4 @@ def run_with_ngrok(app):
         thread.start()
         old_run(*args, **kwargs)
     app.run = new_run
+


### PR DESCRIPTION
A fix for #29 

The `platform.system() `output for the Raspberry Pi OS is also `'Linux'`. 
https://github.com/gstaff/flask-ngrok/blob/33a2e70898c4fb72b645715dacd8789769a99350/flask_ngrok.py#L50

This leads to a download of the wrong ngrok executable for ARM devices.

Added an additional if else statement in line [#55 flask_ngrok.py ](https://github.com/srividya-p/flask-ngrok/blob/46096d1dc121e04187a73573bd1da9a32b0c9841/flask_ngrok.py#L55)

```
elif system == "Linux":
        if 'arm' in os.uname().machine and platform.architecture()[0] == '64bit':
            url="https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-arm64.zip"
        elif 'arm' in os.uname().machine and platform.architecture()[0] == '32bit':
            url="https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-arm.zip"
        else:
            url = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip"
```