### PR TITLE
Now uses ngrok's auth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,30 +15,31 @@ Python 3.6+ is required.
 ```bash
 pip install flask-ngrok
 ```
-### Inside Jupyter / Colab Notebooks
-Notebooks have [an issue](https://stackoverflow.com/questions/51180917/python-flask-unsupportedoperation-not-writable) with newer versions of Flask, so force an older version if working in these environments.
-```bash
-!pip install flask==0.12.2
-```
 See the [example notebook](https://colab.research.google.com/github/gstaff/flask-ngrok/blob/master/examples/flask_ngrok_example.ipynb) for a working example.
 
 ## Quickstart
+0. Signup on `ngrok` to get an auth token.
 1. Import with ```from flask_ngrok import run_with_ngrok```
-2. Add `run_with_ngrok(app)` to make your Flask app available upon running
+2. Add `run_with_ngrok(app, 'YOUR AUTH TOKEN')` to make your Flask app available upon running
 ```python
-# flask_ngrok_example.py
+# examples/flask_ngrok_example.py
 from flask import Flask
+import os
+
 from flask_ngrok import run_with_ngrok
 
 app = Flask(__name__)
-run_with_ngrok(app)  # Start ngrok when app is run
+run_with_ngrok(app, '<YOUR AUTH TOKEN HERE>')  # Start ngrok when app is run
+
 
 @app.route("/")
 def hello():
     return "Hello World!"
 
+
 if __name__ == '__main__':
     app.run()
+
 ```
 Running the example:
 ```bash

--- a/examples/flask_ngrok_example.ipynb
+++ b/examples/flask_ngrok_example.ipynb
@@ -1,48 +1,35 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "flask-ngrok-example.ipynb",
-      "version": "0.3.2",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
-  },
   "cells": [
     {
-      "metadata": {
-        "id": "1cljkrUaPeyg",
-        "colab_type": "code",
-        "colab": {}
-      },
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "1cljkrUaPeyg"
+      },
+      "outputs": [],
       "source": [
         "!pip install flask-ngrok\n",
-        "!pip install flask==0.12.2  # Newer versions of flask don't work in Colab\n",
-        "                            # See https://github.com/plotly/dash/issues/257"
-      ],
-      "execution_count": 0,
-      "outputs": []
+        "!pip install flask"
+      ]
     },
     {
-      "metadata": {
-        "id": "H39hVXhiPtBo",
-        "colab_type": "code",
-        "colab": {}
-      },
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "H39hVXhiPtBo"
+      },
+      "outputs": [],
       "source": [
         "# flask_ngrok_example.py\n",
         "from flask import Flask\n",
         "from flask_ngrok import run_with_ngrok\n",
         "\n",
         "app = Flask(__name__)\n",
-        "run_with_ngrok(app)  # Start ngrok when app is run\n",
+        "run_with_ngrok(app, '<YOUR AUTH TOKEN HERE>')  # Start ngrok when app is run\n",
         "\n",
         "@app.route(\"/\")\n",
         "def hello():\n",
@@ -51,9 +38,21 @@
         "if __name__ == '__main__':\n",
         "    app.run()  # If address is in use, may need to terminate other sessions:\n",
         "               # Runtime > Manage Sessions > Terminate Other Sessions"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [],
+      "name": "flask-ngrok-example.ipynb",
+      "provenance": [],
+      "version": "0.3.2"
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/examples/flask_ngrok_example.py
+++ b/examples/flask_ngrok_example.py
@@ -1,9 +1,10 @@
 from flask import Flask
+import os
 
 from flask_ngrok import run_with_ngrok
 
 app = Flask(__name__)
-run_with_ngrok(app)  # Start ngrok when app is run
+run_with_ngrok(app, '<YOUR AUTH TOKEN HERE>')  # Start ngrok when app is run
 
 
 @app.route("/")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="flask-ngrok",
-    version="0.0.26",
+    version="0.0.27",
     author="Grant Stafford",
     description="A simple way to demo Flask apps from your machine.",
     long_description=long_description,


### PR DESCRIPTION
This commit adds support for ngrok auth tokens as it is not possible to use ngrok without them.
No issues with newer versions of flask in google colab.

Have a nice day!